### PR TITLE
Update GitHub Actions Workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [12]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install


### PR DESCRIPTION
Do not use deprecated actions. 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/